### PR TITLE
Removed hardcoded parity version, switched to last stable. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 * [Node.js](https://nodejs.org) >= 8.*
 * [MongoDB](https://www.mongodb.com) >= 3.4
-* [Parity](https://github.com/paritytech/parity/releases/tag/v1.9.6) 1.9.6-stable
+* [Parity](https://github.com/paritytech/parity-ethereum/releases) latest stable
 
 The following node packages or their dependencies uses native libraries:
 * [bcrypt](https://github.com/kelektiv/node.bcrypt.js)
@@ -20,7 +20,7 @@ Please take care for the dependencies of the build tool [node-gyp](https://githu
 
 #### Parity
 
-See [Configuring Parity](https://wiki.parity.io/Configuring-Parity) for the complete documentation.
+See [Configuring Parity](https://wiki.parity.io/Configuring-Parity-Ethereum) for the complete documentation.
 
 #### Backend
 

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -27,6 +27,7 @@ echo "creating openshift project..."
 oc new-project $oc_project_name
 echo "creating parity pod..."
 oc create -f parity-template.yml
-oc new-app parity -p PARITY_VERSION=v1.9.6
+oc new-app parity -p PARITY_VERSION=stable
+# -p PARITY_VERSION=v1.9.6
 echo "creating client and backend..."
 oc process -f blockchain-app-template.yml -p API_URL=http://blockchain-app-backend-${oc_project_name}.${oc_wildcard_domain}/api/v1/ | oc create -f -

--- a/openshift/parity-template.yml
+++ b/openshift/parity-template.yml
@@ -62,7 +62,7 @@ objects:
           command: ["/bin/sh"]
           args:
           - -c
-          - "umask 0002; /parity/parity --config /opt/parity/conf/config.toml"
+          - "umask 0002; /bin/parity --config /opt/parity/conf/config.toml"
           volumeMounts:
           - name: parity-config
             mountPath: /opt/parity/conf
@@ -230,5 +230,5 @@ parameters:
 - name: PARITY_VERSION
   displayName: Parity Image Tag
   description: 'Version of the Parity container image. Check the available version https://hub.docker.com/r/parity/parity/tags/'
-  value: "v2.0.1"
+  value: "stable"
   required: true


### PR DESCRIPTION
Changed parity executable path. Tested on OCP 4.1